### PR TITLE
配置grpc客户端全局拦截器

### DIFF
--- a/sample/netcore/Overt.GrpcExample.Client/ClientLoggerInterceptor.cs
+++ b/sample/netcore/Overt.GrpcExample.Client/ClientLoggerInterceptor.cs
@@ -1,0 +1,109 @@
+﻿using Grpc.Core;
+using Grpc.Core.Interceptors;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Overt.GrpcExample.Client
+{
+    public class ClientLoggerInterceptor : Interceptor
+    {
+        public override AsyncUnaryCall<TResponse> AsyncUnaryCall<TRequest, TResponse>(
+            TRequest request,
+            ClientInterceptorContext<TRequest, TResponse> context,
+            AsyncUnaryCallContinuation<TRequest, TResponse> continuation)
+        {
+            LogCall(context.Method);
+            AddCallerMetadata(ref context);
+
+            var call = continuation(request, context);
+
+            return new AsyncUnaryCall<TResponse>(HandleResponse(call.ResponseAsync), call.ResponseHeadersAsync, call.GetStatus, call.GetTrailers, call.Dispose);
+        }
+
+        private async Task<TResponse> HandleResponse<TResponse>(Task<TResponse> t)
+        {
+            try
+            {
+                var response = await t;
+                Console.WriteLine($"Response received: {response}");
+                return response;
+            }
+            catch (Exception ex)
+            {
+                // Log error to the console.
+                // Note: Configuring .NET Core logging is the recommended way to log errors
+                // https://docs.microsoft.com/aspnet/core/grpc/diagnostics#grpc-client-logging
+                var initialColor = Console.ForegroundColor;
+                Console.ForegroundColor = ConsoleColor.Red;
+                Console.WriteLine($"Call error: {ex.Message}");
+                Console.ForegroundColor = initialColor;
+
+                throw;
+            }
+        }
+
+        public override AsyncClientStreamingCall<TRequest, TResponse> AsyncClientStreamingCall<TRequest, TResponse>(
+            ClientInterceptorContext<TRequest, TResponse> context,
+            AsyncClientStreamingCallContinuation<TRequest, TResponse> continuation)
+        {
+            LogCall(context.Method);
+            AddCallerMetadata(ref context);
+
+            return continuation(context);
+        }
+
+        public override AsyncServerStreamingCall<TResponse> AsyncServerStreamingCall<TRequest, TResponse>(
+            TRequest request,
+            ClientInterceptorContext<TRequest, TResponse> context,
+            AsyncServerStreamingCallContinuation<TRequest, TResponse> continuation)
+        {
+            LogCall(context.Method);
+            AddCallerMetadata(ref context);
+
+            return continuation(request, context);
+        }
+
+        public override AsyncDuplexStreamingCall<TRequest, TResponse> AsyncDuplexStreamingCall<TRequest, TResponse>(
+            ClientInterceptorContext<TRequest, TResponse> context,
+            AsyncDuplexStreamingCallContinuation<TRequest, TResponse> continuation)
+        {
+            LogCall(context.Method);
+            AddCallerMetadata(ref context);
+
+            return continuation(context);
+        }
+
+        private void LogCall<TRequest, TResponse>(Method<TRequest, TResponse> method)
+            where TRequest : class
+            where TResponse : class
+        {
+            var initialColor = Console.ForegroundColor;
+            Console.ForegroundColor = ConsoleColor.Green;
+            Console.WriteLine($"Starting call. Type: {method.Type}. Request: {typeof(TRequest)}. Response: {typeof(TResponse)}");
+            Console.ForegroundColor = initialColor;
+        }
+
+        private void AddCallerMetadata<TRequest, TResponse>(ref ClientInterceptorContext<TRequest, TResponse> context)
+            where TRequest : class
+            where TResponse : class
+        {
+            var headers = context.Options.Headers;
+
+            // Call doesn't have a headers collection to add to.
+            // Need to create a new context with headers for the call.
+            if (headers == null)
+            {
+                headers = new Metadata();
+                var options = context.Options.WithHeaders(headers);
+                context = new ClientInterceptorContext<TRequest, TResponse>(context.Method, context.Host, options);
+            }
+
+            // Add caller metadata to call headers
+            headers.Add("caller-user", Environment.UserName);
+            headers.Add("caller-machine", Environment.MachineName);
+            headers.Add("caller-os", Environment.OSVersion.ToString());
+        }
+    }
+}

--- a/sample/netcore/Overt.GrpcExample.Client/Program.cs
+++ b/sample/netcore/Overt.GrpcExample.Client/Program.cs
@@ -25,7 +25,9 @@ namespace Overt.GrpcExample.Client
 
             // 注入GrpcClient
             services.AddGrpcClient<ConsoleTracer>();
-
+            services.Configure<GrpcClientFactoryOptions>(options => {
+                options.Interceptors.Add(new ClientLoggerInterceptor());
+            });
             // 第三方配置，启动可用
             //services.AddGrpcConfig(config =>
             //{

--- a/src/Overt.Core.Grpc/Client/ClientGenerate/GrpcClientFactoryOptions.cs
+++ b/src/Overt.Core.Grpc/Client/ClientGenerate/GrpcClientFactoryOptions.cs
@@ -1,0 +1,17 @@
+﻿using Grpc.Core.Interceptors;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Overt.Core.Grpc
+{
+   public class GrpcClientFactoryOptions
+    {
+        /// <summary>
+        /// Gets a list of <see cref="Interceptor"/> instances used to configure a gRPC client pipeline.
+        /// </summary>
+        public IList<Interceptor> Interceptors { get; } = new List<Interceptor>();
+    }
+}


### PR DESCRIPTION
目前虽然grpc客户端有实现 IClientTracer ，但对于某些特殊的拦截需求，IClientTracer仍然不能满足，如: 系统需集成[OpenTelemeTry](https://github.com/pcwiese/opentelemetry-dotnet-contrib/blob/pwiese/grpc-core-otel/src/OpenTelemetry.Contrib.Instrumentation.GrpcCore/ClientTracingInterceptor.cs)的grpc客户端拦截器时。

故，提交实现简单的全局拦截器配置，后期再实现根据不同的ClientBase，配置不同需求的拦截器。